### PR TITLE
Implement week publishing workflow and UI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,127 @@
-# Staffany Take Home Test
+# StaffAny Scheduler Assignment
 
-You are free to modify the starting code, but you are not allowed to entirely throw out the existing code. Part of the assessment criteria is to understand how well you can understand and utilize existing code.
+This repository contains the backend (Hapi + TypeORM) and frontend (React + Material UI + Redux) implementations for the StaffAny scheduling assignment. The solution extends the starter project with week-based publishing, clash detection, and UI enhancements that match the provided mockups.
 
-## How to install and run
+## Project Structure
 
-1. Install PostgresDB (v14 and up)
-2. Install NodeJS (v22 and up)
-3. `npm i` in each repo
-4. Follow respective readme
+```
+├── backend   # Hapi API server (TypeScript)
+└── frontend  # React application (TypeScript)
+```
+
+---
+
+## Backend
+
+### Tech Stack
+- **Framework:** Hapi.js
+- **Database:** PostgreSQL
+- **ORM:** TypeORM
+- **Language:** TypeScript
+
+### Environment Variables
+Create a `.env` file inside `backend/` (already included) and adjust as needed:
+```
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_NAME=staffany
+PORT=3000
+BASE_API_PATH=/api
+```
+
+### Installation & Setup
+1. Ensure PostgreSQL and Node.js (v22+) are installed and running.
+2. From the repository root run:
+   ```bash
+   cd backend
+   npm install
+   ./createdb.sh   # creates the database defined in .env
+   npm run dev     # starts the Hapi server on http://localhost:3000
+   ```
+
+### API Endpoints
+Base URL: `http://localhost:3000/api/v1`
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| GET    | `/shifts?weekStartDate=YYYY-MM-DD` | List shifts for the selected week (inclusive Monday–Sunday). Returns sanitized time strings and week metadata. |
+| GET    | `/shifts/{id}` | Retrieve a single shift with week information. |
+| POST   | `/shifts` | Create a shift. Rejects overlapping shifts unless `ignoreClash=true` is provided. |
+| PATCH  | `/shifts/{id}` | Update a shift. Rejects edits on published shifts or moves into published weeks. Supports `ignoreClash`. |
+| DELETE | `/shifts/{id}` | Delete a shift (only allowed if its week is unpublished). |
+| GET    | `/weeks/{weekStartDate}` | Fetch publishing metadata (published flag, publishedAt) for a week. Weeks are automatically created on demand. |
+| POST   | `/weeks/{weekStartDate}/publish` | Publish all shifts within the week. Rejects empty weeks or already published weeks. |
+
+### Business Rules & Validations
+- **Shift duration**: Using the input date as start day, determine if end time spills into the next day. Duration must satisfy `0 < duration < 24h`. Shifts ending exactly when the next day starts are rejected.
+- **Clash detection**: Shifts are normalized to `[startAt, endAt)` timestamps and compared with overlapping logic (`startA < endB && startB < endA`). Cross-midnight overlaps are accounted for. Boundary cases where one shift ends when another starts are permitted.
+- **Ignore clash**: Create and update endpoints accept `ignoreClash=true`. Without the flag the API returns `409` with details of the conflicting shift.
+- **Publishing**:
+  - Publishing applies to an entire week (Monday–Sunday).
+  - Once published, all shifts in that week become immutable (no create/update/delete allowed).
+  - Publishing an empty week is rejected.
+  - Attempting to move a shift into a published week is rejected.
+
+Responses use a consistent structure (`statusCode`, `message`, `results`) and errors include `data` when extra context (e.g., clash details) is required.
+
+---
+
+## Frontend
+
+### Tech Stack
+- **Framework:** React (TypeScript)
+- **UI Library:** Material UI
+- **State Management:** Redux (with a custom reducer)
+- **Routing:** React Router v5
+
+### Environment Variables
+Create `frontend/.env` (already included) with:
+```
+REACT_APP_API_BASE_URL=http://localhost:3000/api/v1
+```
+
+### Installation & Development
+1. From the repository root run:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev   # starts CRA dev server on http://localhost:3000
+   ```
+   Ensure the backend server is running so the API calls succeed.
+
+### Features Implemented
+- **Week picker**: Arrow navigation and calendar picker allow viewing any week. The selected week is synced to the URL query (`?week=YYYY-MM-DD`) so browser navigation restores the same week.
+- **Shift table**: Table layout matches the mock (name/date/start/end/actions). Loading and empty states are provided. Actions are disabled for published weeks.
+- **Create/Edit form**:
+  - `Add Shift` button relocated to the card header; defaults date to the Monday of the selected week, start time to the current hour, end time to the next hour.
+  - Clash warnings display a modal with the conflicting shift and offer *Cancel* or *Ignore* options.
+  - After save the user is redirected back to the relevant week (based on the shift's week).
+- **Publishing controls**: Publish button (with confirmation dialog) publishes an entire week. Once published, Add/Edit/Delete/Publish are disabled and a green banner indicates the publish timestamp.
+- **Redux store**: Maintains selected week, schedule data, loading states, and errors. API interactions are coordinated through action dispatches in the component layer.
+
+### UI Notes
+- Styles adhere closely to the provided mockups (navy header, turquoise buttons, typography).
+- Error handling uses dismissible Material UI alerts.
+- Confirm dialogs reuse a shared component with customizable labels.
+- Clash modal uses standard MUI dialogs to display the required copy.
+
+---
+
+## Testing & Verification
+- Run `npm test` in each project for unit tests (none provided by default).
+- Manual verification:
+  - Create, update, delete shifts and validate clash detection.
+  - Publish a week, ensure shifts become read-only and new creation is blocked.
+  - Cross-midnight shifts (e.g., 20:00 → 02:00) are permitted and properly detected for clashes.
+  - Navigation via week picker maintains state when navigating away/back.
+
+---
+
+## Additional Notes
+- The backend uses TypeORM synchronize mode for convenience. In production, migrations are recommended.
+- The Redux store uses vanilla Redux to avoid introducing extra dependencies; asynchronous API calls are orchestrated within components while reducers manage the canonical state.
+- `.env` files are committed as requested for easier setup.
+
+Feel free to reach out if clarification or additional documentation is required.

--- a/backend/.env
+++ b/backend/.env
@@ -1,7 +1,7 @@
-PORT=3000
-
 DB_HOST=localhost
 DB_PORT=5432
-DB_USERNAME=staffany_admin
-DB_PASSWORD=assignment
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
 DB_NAME=staffany
+PORT=3000
+BASE_API_PATH=/api

--- a/backend/src/database/default/entity/shift.ts
+++ b/backend/src/database/default/entity/shift.ts
@@ -1,5 +1,12 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from "typeorm";
 import { BaseTimestamp } from "./baseTimestamp";
+import Week from "./week";
 
 @Entity()
 export default class Shift extends BaseTimestamp {
@@ -23,4 +30,20 @@ export default class Shift extends BaseTimestamp {
     type: "time",
   })
   endTime: string;
+
+  @Column({ type: "boolean", default: false })
+  isPublished: boolean;
+
+  @Column({ type: "timestamptz", nullable: true })
+  publishedAt: Date | null;
+
+  @Column({ type: "uuid" })
+  weekId: string;
+
+  @ManyToOne(() => Week, (week) => week.shifts, {
+    nullable: false,
+    onDelete: "CASCADE",
+  })
+  @JoinColumn({ name: "weekId" })
+  week: Week;
 }

--- a/backend/src/database/default/entity/week.ts
+++ b/backend/src/database/default/entity/week.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "typeorm";
+import { BaseTimestamp } from "./baseTimestamp";
+import Shift from "./shift";
+
+@Entity()
+export default class Week extends BaseTimestamp {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column({ type: "date", unique: true })
+  startDate: string;
+
+  @Column({ type: "date" })
+  endDate: string;
+
+  @Column({ type: "boolean", default: false })
+  isPublished: boolean;
+
+  @Column({ type: "timestamptz", nullable: true })
+  publishedAt: Date | null;
+
+  @OneToMany(() => Shift, (shift) => shift.week)
+  shifts: Shift[];
+}

--- a/backend/src/database/default/repository/shiftRepository.ts
+++ b/backend/src/database/default/repository/shiftRepository.ts
@@ -4,6 +4,7 @@ import {
   FindOneOptions,
   FindOptionsWhere,
   DeleteResult,
+  UpdateResult,
 } from "typeorm";
 import moduleLogger from "../../../shared/functions/logger";
 import Shift from "../entity/shift";
@@ -58,7 +59,7 @@ export const updateById = async (
   logger.info("Update by id");
   const repository = getRepository(Shift);
   await repository.update(id, payload);
-  return findById(id);
+  return findById(id, { relations: ["week"] });
 };
 
 export const deleteById = async (
@@ -68,3 +69,13 @@ export const deleteById = async (
   const repository = getRepository(Shift);
   return await repository.delete(id);
 };
+
+export const updateWhere = async (
+  where: FindOptionsWhere<Shift>,
+  payload: QueryDeepPartialEntity<Shift>
+): Promise<UpdateResult> => {
+  logger.info("Update where");
+  const repository = getRepository(Shift);
+  return repository.update(where, payload);
+};
+

--- a/backend/src/database/default/repository/weekRepository.ts
+++ b/backend/src/database/default/repository/weekRepository.ts
@@ -1,0 +1,37 @@
+import { FindOptionsWhere, getRepository } from "typeorm";
+import Week from "../entity/week";
+import moduleLogger from "../../../shared/functions/logger";
+import { QueryDeepPartialEntity } from "typeorm/query-builder/QueryPartialEntity";
+
+const logger = moduleLogger("weekRepository");
+
+export const findById = async (id: string): Promise<Week | null> => {
+  logger.info("Find week by id");
+  const repository = getRepository(Week);
+  return repository.findOne({ where: { id } });
+};
+
+export const findOne = async (
+  where: FindOptionsWhere<Week>
+): Promise<Week | null> => {
+  logger.info("Find week by query");
+  const repository = getRepository(Week);
+  return repository.findOne({ where });
+};
+
+export const create = async (payload: Partial<Week>): Promise<Week> => {
+  logger.info("Create week");
+  const repository = getRepository(Week);
+  const week = repository.create(payload);
+  return repository.save(week);
+};
+
+export const updateById = async (
+  id: string,
+  payload: QueryDeepPartialEntity<Week>
+): Promise<Week | null> => {
+  logger.info("Update week");
+  const repository = getRepository(Week);
+  await repository.update(id, payload);
+  return findById(id);
+};

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -1,6 +1,8 @@
 import { Server } from "@hapi/hapi";
 import createShiftRoutes from "./shifts";
+import createWeekRoutes from "./weeks";
 
 export default function (server: Server, basePath: string) {
   createShiftRoutes(server, basePath + "/shifts");
+  createWeekRoutes(server, basePath + "/weeks");
 }

--- a/backend/src/routes/v1/shifts/index.ts
+++ b/backend/src/routes/v1/shifts/index.ts
@@ -1,6 +1,6 @@
 import { Server } from '@hapi/hapi';
 import * as shiftController from './shiftController';
-import { createShiftDto, filterSchema, idDto, updateShiftDto } from '../../../shared/dtos';
+import { createShiftDto, idDto, listShiftQueryDto, updateShiftDto } from '../../../shared/dtos';
 
 export default function (server: Server, basePath: string) {
   server.route({
@@ -10,7 +10,10 @@ export default function (server: Server, basePath: string) {
     options: {
       description: 'Get shifts with filter',
       notes: 'Get all shifts if filter is not specified.',
-      tags: ['api', 'shift']
+      tags: ['api', 'shift'],
+      validate: {
+        query: listShiftQueryDto,
+      },
     }
   });
   

--- a/backend/src/routes/v1/shifts/shiftController.ts
+++ b/backend/src/routes/v1/shifts/shiftController.ts
@@ -13,8 +13,10 @@ const logger = moduleLogger("shiftController");
 export const find = async (req: Request, h: ResponseToolkit) => {
   logger.info("Find shifts");
   try {
-    const filter = req.query;
-    const data = await shiftUsecase.find(filter);
+    const { weekStartDate } = req.query as {
+      weekStartDate?: string;
+    };
+    const data = await shiftUsecase.find({ weekStartDate });
     const res: ISuccessResponse = {
       statusCode: 200,
       message: "Get shift successful",

--- a/backend/src/routes/v1/weeks/index.ts
+++ b/backend/src/routes/v1/weeks/index.ts
@@ -1,0 +1,33 @@
+import { Server } from "@hapi/hapi";
+import { weekStartParamDto } from "../../../shared/dtos";
+import * as weekController from "./weekController";
+
+export default function (server: Server, basePath: string) {
+  server.route({
+    method: "GET",
+    path: `${basePath}/{weekStartDate}`,
+    handler: weekController.findByStartDate,
+    options: {
+      description: "Get week information",
+      notes: "Get publishing metadata for a week",
+      tags: ["api", "week"],
+      validate: {
+        params: weekStartParamDto,
+      },
+    },
+  });
+
+  server.route({
+    method: "POST",
+    path: `${basePath}/{weekStartDate}/publish`,
+    handler: weekController.publish,
+    options: {
+      description: "Publish week",
+      notes: "Publish all shifts within a week",
+      tags: ["api", "week"],
+      validate: {
+        params: weekStartParamDto,
+      },
+    },
+  });
+}

--- a/backend/src/routes/v1/weeks/weekController.ts
+++ b/backend/src/routes/v1/weeks/weekController.ts
@@ -1,0 +1,45 @@
+import { Request, ResponseToolkit } from "@hapi/hapi";
+import * as weekUsecase from "../../../usecases/weekUsecase";
+import { errorHandler } from "../../../shared/functions/error";
+import { ISuccessResponse } from "../../../shared/interfaces";
+import moduleLogger from "../../../shared/functions/logger";
+
+const logger = moduleLogger("weekController");
+
+export const findByStartDate = async (req: Request, h: ResponseToolkit) => {
+  logger.info("Find week by start date");
+  try {
+    const { weekStartDate } = req.params as { weekStartDate: string };
+    const data = await weekUsecase.getWeekByStartDate(weekStartDate);
+
+    const res: ISuccessResponse = {
+      statusCode: 200,
+      message: "Get week successful",
+      results: data,
+    };
+
+    return res;
+  } catch (error) {
+    logger.error(error.message);
+    return errorHandler(h, error);
+  }
+};
+
+export const publish = async (req: Request, h: ResponseToolkit) => {
+  logger.info("Publish week");
+  try {
+    const { weekStartDate } = req.params as { weekStartDate: string };
+    const data = await weekUsecase.publishWeek(weekStartDate);
+
+    const res: ISuccessResponse = {
+      statusCode: 200,
+      message: "Publish week successful",
+      results: data,
+    };
+
+    return res;
+  } catch (error) {
+    logger.error(error.message);
+    return errorHandler(h, error);
+  }
+};

--- a/backend/src/shared/classes/HttpError.ts
+++ b/backend/src/shared/classes/HttpError.ts
@@ -8,9 +8,12 @@ export class HttpError extends Error {
 
   public message: string;
 
-  constructor(status: number, message: string) {
+  public data?: unknown;
+
+  constructor(status: number, message: string, data?: unknown) {
     super(message);
     this.status = status;
     this.message = message;
+    this.data = data;
   }
 }

--- a/backend/src/shared/dtos/index.ts
+++ b/backend/src/shared/dtos/index.ts
@@ -6,3 +6,4 @@ export const idDto = Joi.object({
 
 export * from "./filter";
 export * from "./shift";
+export * from "./week";

--- a/backend/src/shared/dtos/shift.ts
+++ b/backend/src/shared/dtos/shift.ts
@@ -6,12 +6,18 @@ export const createShiftDto = Joi.object({
   name: Joi.string().required(),
   date: Joi.date().required(),
   startTime: Joi.string().regex(timeRegex).required(),
-  endTime:Joi.string().regex(timeRegex).required()
+  endTime: Joi.string().regex(timeRegex).required(),
+  ignoreClash: Joi.boolean(),
 });
 
 export const updateShiftDto = Joi.object({
   name: Joi.string(),
   date: Joi.date(),
   startTime: Joi.string().regex(timeRegex),
-  endTime:Joi.string().regex(timeRegex),
+  endTime: Joi.string().regex(timeRegex),
+  ignoreClash: Joi.boolean(),
+});
+
+export const listShiftQueryDto = Joi.object({
+  weekStartDate: Joi.date(),
 });

--- a/backend/src/shared/dtos/week.ts
+++ b/backend/src/shared/dtos/week.ts
@@ -1,0 +1,5 @@
+import Joi from "joi";
+
+export const weekStartParamDto = Joi.object({
+  weekStartDate: Joi.date().required(),
+});

--- a/backend/src/shared/functions/error.ts
+++ b/backend/src/shared/functions/error.ts
@@ -7,13 +7,14 @@ export const errorHandler = (h: ResponseToolkit, err: any) => {
     return h.response({
       error: err.name,
       statusCode: err.status,
-      message: err.message
+      message: err.message,
+      data: err.data,
     } as IErrorResponse).code(err.status);
   }
 
   return h.response({
     statusCode: 500,
     error: "Internal server error",
-    message: err.message
+    message: err.message,
   } as IErrorResponse).code(500);
 }

--- a/backend/src/shared/functions/index.ts
+++ b/backend/src/shared/functions/index.ts
@@ -1,1 +1,2 @@
-export * from './error';
+export * from "./error";
+export * from "./shiftTime";

--- a/backend/src/shared/functions/shiftTime.ts
+++ b/backend/src/shared/functions/shiftTime.ts
@@ -1,0 +1,92 @@
+import { addMinutes, addDays, format, parseISO, startOfWeek } from "date-fns";
+import { HttpError } from "../classes/HttpError";
+
+const MINUTES_IN_DAY = 24 * 60;
+
+export interface ShiftInterval {
+  startAt: Date;
+  endAt: Date;
+  durationMinutes: number;
+  dayOffset: number;
+}
+
+const normalizeTimeString = (time: string): string => {
+  if (!time.includes(":")) {
+    throw new HttpError(400, "Invalid time format");
+  }
+
+  const [hours, minutes] = time.split(":");
+  const normalizedMinutes = minutes?.slice(0, 2) ?? "00";
+
+  return `${hours.padStart(2, "0")}:${normalizedMinutes.padStart(2, "0")}`;
+};
+
+const timeToMinutes = (time: string): number => {
+  const [hourStr, minuteStr] = time.split(":");
+  const hours = Number(hourStr);
+  const minutes = Number(minuteStr);
+
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    throw new HttpError(400, "Invalid time value");
+  }
+
+  return hours * 60 + minutes;
+};
+
+export const calculateShiftInterval = (
+  date: string,
+  startTime: string,
+  endTime: string
+): ShiftInterval => {
+  const normalizedStart = normalizeTimeString(startTime);
+  const normalizedEnd = normalizeTimeString(endTime);
+
+  const startMinutes = timeToMinutes(normalizedStart);
+  const endMinutes = timeToMinutes(normalizedEnd);
+
+  const dayOffset = endMinutes <= startMinutes ? 1 : 0;
+  const duration = endMinutes - startMinutes + dayOffset * MINUTES_IN_DAY;
+
+  if (duration <= 0) {
+    throw new HttpError(400, "Shift duration must be greater than 0");
+  }
+
+  if (duration >= MINUTES_IN_DAY) {
+    throw new HttpError(400, "Shift duration must be shorter than 24 hours");
+  }
+
+  const startDate = parseISO(`${date}`);
+  if (Number.isNaN(startDate.getTime())) {
+    throw new HttpError(400, "Invalid date value");
+  }
+
+  const startAt = addMinutes(new Date(`${date}T00:00:00.000Z`), startMinutes);
+  const endAt = addMinutes(startAt, duration);
+
+  return {
+    startAt,
+    endAt,
+    durationMinutes: duration,
+    dayOffset,
+  };
+};
+
+export const getWeekBounds = (date: string) => {
+  const parsed = parseISO(date);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new HttpError(400, "Invalid date value");
+  }
+  const start = startOfWeek(parsed, { weekStartsOn: 1 });
+  const end = addDays(start, 6);
+
+  return {
+    weekStartDate: format(start, "yyyy-MM-dd"),
+    weekEndDate: format(end, "yyyy-MM-dd"),
+  };
+};
+
+export const formatDate = (date: Date, pattern = "yyyy-MM-dd") =>
+  format(date, pattern);
+
+export const formatTime = (date: Date, pattern = "HH:mm") =>
+  format(date, pattern);

--- a/backend/src/shared/interfaces/response.ts
+++ b/backend/src/shared/interfaces/response.ts
@@ -8,4 +8,5 @@ export interface IErrorResponse {
   statusCode: number;
   error: string;
   message: string;
+  data?: unknown;
 }

--- a/backend/src/shared/interfaces/shift.ts
+++ b/backend/src/shared/interfaces/shift.ts
@@ -3,6 +3,7 @@ export interface ICreateShift {
   date: string;
   startTime: string;
   endTime: string;
+  ignoreClash?: boolean;
 }
 
 export interface IUpdateShift {
@@ -10,5 +11,5 @@ export interface IUpdateShift {
   date?: string;
   startTime?: string;
   endTime?: string;
-  weekId? : string;
+  ignoreClash?: boolean;
 }

--- a/backend/src/usecases/shiftUsecase.ts
+++ b/backend/src/usecases/shiftUsecase.ts
@@ -1,38 +1,249 @@
+import { Between } from "typeorm";
 import * as shiftRepository from "../database/default/repository/shiftRepository";
-import { FindManyOptions, FindOneOptions } from "typeorm";
+import * as weekRepository from "../database/default/repository/weekRepository";
 import Shift from "../database/default/entity/shift";
-import { ICreateShift, IUpdateShift } from "../shared/interfaces";
+import Week from "../database/default/entity/week";
+import { calculateShiftInterval, getWeekBounds } from "../shared/functions";
+import { HttpError } from "../shared/classes/HttpError";
+import {
+  ICreateShift,
+  IUpdateShift,
+} from "../shared/interfaces";
+import { addDays, format } from "date-fns";
 
-export const find = async (opts: FindManyOptions<Shift>): Promise<Shift[]> => {
-  return shiftRepository.find(opts);
+interface IFindShiftParams {
+  weekStartDate?: string;
+}
+
+const sanitizeTime = (time: string) =>
+  time.length > 5 ? time.slice(0, 5) : time;
+
+const mapShiftResponse = (shift: Shift) => ({
+  id: shift.id,
+  name: shift.name,
+  date: shift.date,
+  startTime: sanitizeTime(shift.startTime),
+  endTime: sanitizeTime(shift.endTime),
+  isPublished: shift.isPublished,
+  publishedAt: shift.publishedAt,
+  week: shift.week
+    ? {
+        id: shift.week.id,
+        startDate: shift.week.startDate,
+        endDate: shift.week.endDate,
+        isPublished: shift.week.isPublished,
+        publishedAt: shift.week.publishedAt,
+      }
+    : null,
+});
+
+const getOrCreateWeek = async (date: string): Promise<Week> => {
+  const { weekStartDate, weekEndDate } = getWeekBounds(date);
+  let week = await weekRepository.findOne({ startDate: weekStartDate });
+
+  if (!week) {
+    week = await weekRepository.create({
+      startDate: weekStartDate,
+      endDate: weekEndDate,
+      isPublished: false,
+      publishedAt: null,
+    });
+  }
+
+  return week;
 };
 
-export const findById = async (
-  id: string,
-  opts?: FindOneOptions<Shift>
-): Promise<Shift> => {
-  return shiftRepository.findById(id, opts);
-};
+const findClashingShift = async (
+  candidate: { date: string; startTime: string; endTime: string },
+  excludeShiftId?: string
+): Promise<Shift | null> => {
+  const interval = calculateShiftInterval(
+    candidate.date,
+    candidate.startTime,
+    candidate.endTime
+  );
 
-export const create = async (payload: ICreateShift): Promise<Shift> => {
-  const shift = new Shift();
-  shift.name = payload.name;
-  shift.date = payload.date;
-  shift.startTime = payload.startTime;
-  shift.endTime = payload.endTime;
+  const rangeStart = format(addDays(new Date(`${candidate.date}T00:00:00.000Z`), -1), "yyyy-MM-dd");
+  const rangeEnd = format(
+    addDays(new Date(`${candidate.date}T00:00:00.000Z`), 1),
+    "yyyy-MM-dd"
+  );
 
-  return shiftRepository.create(shift);
-};
-
-export const updateById = async (
-  id: string,
-  payload: IUpdateShift
-): Promise<Shift> => {
-  return shiftRepository.updateById(id, {
-    ...payload,
+  const candidates = await shiftRepository.find({
+    where: {
+      date: Between(rangeStart, rangeEnd),
+    },
+    relations: ["week"],
   });
+
+  return (
+    candidates
+      .filter((shift) => shift.id !== excludeShiftId)
+      .find((shift) => {
+        const existingInterval = calculateShiftInterval(
+          shift.date,
+          shift.startTime,
+          shift.endTime
+        );
+
+        return (
+          interval.startAt < existingInterval.endAt &&
+          existingInterval.startAt < interval.endAt
+        );
+      }) || null
+  );
+};
+
+export const find = async (params: IFindShiftParams) => {
+  const options = {
+    relations: ["week"],
+    order: {
+      date: "ASC" as const,
+      startTime: "ASC" as const,
+    },
+  };
+
+  let shifts: Shift[] = [];
+
+  if (params?.weekStartDate) {
+    const { weekStartDate, weekEndDate } = getWeekBounds(params.weekStartDate);
+    shifts = await shiftRepository.find({
+      ...options,
+      where: {
+        date: Between(weekStartDate, weekEndDate),
+      },
+    });
+  } else {
+    shifts = await shiftRepository.find(options);
+  }
+
+  return shifts.map(mapShiftResponse);
+};
+
+export const findById = async (id: string) => {
+  const shift = await shiftRepository.findById(id, { relations: ["week"] });
+
+  if (!shift) {
+    throw new HttpError(404, "Shift not found");
+  }
+
+  return mapShiftResponse(shift);
+};
+
+export const create = async (payload: ICreateShift) => {
+  const { ignoreClash, ...shiftPayload } = payload;
+
+  calculateShiftInterval(
+    shiftPayload.date,
+    shiftPayload.startTime,
+    shiftPayload.endTime
+  );
+
+  const week = await getOrCreateWeek(shiftPayload.date);
+
+  if (week.isPublished) {
+    throw new HttpError(400, "Cannot create shift in a published week");
+  }
+
+  const clash = await findClashingShift(shiftPayload);
+
+  if (clash && !ignoreClash) {
+    throw new HttpError(409, "Shift clash detected", {
+      clashingShift: mapShiftResponse(clash),
+    });
+  }
+
+  const shift = new Shift();
+  shift.name = shiftPayload.name;
+  shift.date = shiftPayload.date;
+  shift.startTime = sanitizeTime(shiftPayload.startTime);
+  shift.endTime = sanitizeTime(shiftPayload.endTime);
+  shift.week = week;
+  shift.weekId = week.id;
+  shift.isPublished = week.isPublished;
+  shift.publishedAt = week.isPublished ? week.publishedAt : null;
+
+  const created = await shiftRepository.create(shift);
+  const createdShift = await shiftRepository.findById(created.id, {
+    relations: ["week"],
+  });
+
+  if (!createdShift) {
+    throw new HttpError(500, "Unable to load created shift");
+  }
+
+  return mapShiftResponse(createdShift);
+};
+
+export const updateById = async (id: string, payload: IUpdateShift) => {
+  const existingShift = await shiftRepository.findById(id, { relations: ["week"] });
+
+  if (!existingShift) {
+    throw new HttpError(404, "Shift not found");
+  }
+
+  if (existingShift.week?.isPublished || existingShift.isPublished) {
+    throw new HttpError(400, "Cannot edit a published shift");
+  }
+
+  const updatedData = {
+    name: payload.name ?? existingShift.name,
+    date: payload.date ?? existingShift.date,
+    startTime: payload.startTime ?? existingShift.startTime,
+    endTime: payload.endTime ?? existingShift.endTime,
+  };
+
+  calculateShiftInterval(
+    updatedData.date,
+    updatedData.startTime,
+    updatedData.endTime
+  );
+
+  const targetWeek = await getOrCreateWeek(updatedData.date);
+
+  if (targetWeek.isPublished && targetWeek.id !== existingShift.weekId) {
+    throw new HttpError(400, "Cannot move shift into a published week");
+  }
+
+  const clash = await findClashingShift(updatedData, id);
+
+  if (clash && !payload.ignoreClash) {
+    throw new HttpError(409, "Shift clash detected", {
+      clashingShift: mapShiftResponse(clash),
+    });
+  }
+
+  const updatedShift = await shiftRepository.updateById(id, {
+    name: updatedData.name,
+    date: updatedData.date,
+    startTime: sanitizeTime(updatedData.startTime),
+    endTime: sanitizeTime(updatedData.endTime),
+    weekId: targetWeek.id,
+    isPublished: targetWeek.isPublished,
+    publishedAt: targetWeek.isPublished ? targetWeek.publishedAt : null,
+  });
+
+  if (!updatedShift) {
+    throw new HttpError(500, "Unable to load updated shift");
+  }
+
+  return mapShiftResponse(updatedShift);
 };
 
 export const deleteById = async (id: string | string[]) => {
+  if (Array.isArray(id)) {
+    throw new HttpError(400, "Bulk delete is not supported");
+  }
+
+  const existingShift = await shiftRepository.findById(id, { relations: ["week"] });
+
+  if (!existingShift) {
+    throw new HttpError(404, "Shift not found");
+  }
+
+  if (existingShift.week?.isPublished || existingShift.isPublished) {
+    throw new HttpError(400, "Cannot delete a published shift");
+  }
+
   return shiftRepository.deleteById(id);
 };

--- a/backend/src/usecases/weekUsecase.ts
+++ b/backend/src/usecases/weekUsecase.ts
@@ -1,0 +1,86 @@
+import { Between } from "typeorm";
+import * as weekRepository from "../database/default/repository/weekRepository";
+import * as shiftRepository from "../database/default/repository/shiftRepository";
+import { getWeekBounds } from "../shared/functions";
+import { HttpError } from "../shared/classes/HttpError";
+
+const mapWeekResponse = (week: {
+  id?: string;
+  startDate: string;
+  endDate: string;
+  isPublished: boolean;
+  publishedAt: Date | null;
+}) => ({
+  id: week.id ?? null,
+  startDate: week.startDate,
+  endDate: week.endDate,
+  isPublished: week.isPublished,
+  publishedAt: week.publishedAt,
+});
+
+export const getWeekByStartDate = async (weekStartDate: string) => {
+  const { weekStartDate: normalizedStart, weekEndDate } =
+    getWeekBounds(weekStartDate);
+
+  const week = await weekRepository.findOne({ startDate: normalizedStart });
+
+  if (!week) {
+    return mapWeekResponse({
+      startDate: normalizedStart,
+      endDate: weekEndDate,
+      isPublished: false,
+      publishedAt: null,
+    });
+  }
+
+  return mapWeekResponse(week);
+};
+
+export const publishWeek = async (weekStartDate: string) => {
+  const { weekStartDate: normalizedStart, weekEndDate } =
+    getWeekBounds(weekStartDate);
+
+  let week = await weekRepository.findOne({ startDate: normalizedStart });
+
+  if (!week) {
+    week = await weekRepository.create({
+      startDate: normalizedStart,
+      endDate: weekEndDate,
+      isPublished: false,
+      publishedAt: null,
+    });
+  }
+
+  if (week.isPublished) {
+    throw new HttpError(400, "Week is already published");
+  }
+
+  const shifts = await shiftRepository.find({
+    where: {
+      date: Between(normalizedStart, weekEndDate),
+    },
+  });
+
+  if (shifts.length === 0) {
+    throw new HttpError(400, "Cannot publish an empty week");
+  }
+
+  const publishedAt = new Date();
+
+  await weekRepository.updateById(week.id, {
+    isPublished: true,
+    publishedAt,
+  });
+
+  await shiftRepository.updateWhere(
+    { weekId: week.id },
+    {
+      isPublished: true,
+      publishedAt,
+    }
+  );
+
+  const updatedWeek = await weekRepository.findById(week.id);
+
+  return mapWeekResponse(updatedWeek ?? { ...week, isPublished: true, publishedAt });
+};

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,2 +1,1 @@
-PORT=8080
 REACT_APP_API_BASE_URL=http://localhost:3000/api/v1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,6 @@
         "joi": "^17.3.0",
         "nth-check": "^2.1.1",
         "react": "^19.0.0",
-        "react-data-table-component": "^7.6.2",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
         "react-redux": "^9.2.0",
@@ -16782,24 +16781,6 @@
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT"
-    },
-    "node_modules/react-data-table-component": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-data-table-component/-/react-data-table-component-7.6.2.tgz",
-      "integrity": "sha512-nHe7040fmtrJyQr/ieGrTfV0jBflYGK4sLokC6/AFOv3ThjmA9WzKz8Z8/2wMxzRqLU+Rn0CVFg+8+frKLepWQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "deepmerge": "^4.3.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.3",
-        "styled-components": ">= 5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "styled-components": {
-          "optional": false
-        }
-      }
     },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "date-fns": "^2.16.1",
     "joi": "^17.3.0",
     "react": "^19.0.0",
-    "react-data-table-component": "^7.6.2",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
     "react-redux": "^9.2.0",

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -14,6 +14,8 @@ interface Prop {
   onClose: () => void;
   onYes: () => void;
   loading?: boolean;
+  confirmLabel?: string;
+  cancelLabel?: string;
 }
 
 const ConfirmDialog: FunctionComponent<Prop> = ({
@@ -23,6 +25,8 @@ const ConfirmDialog: FunctionComponent<Prop> = ({
   title,
   description,
   loading = false,
+  confirmLabel = "Yes",
+  cancelLabel = "Cancel",
 }) => {
   return (
     <Dialog
@@ -44,10 +48,10 @@ const ConfirmDialog: FunctionComponent<Prop> = ({
         ) : (
           <div>
             <Button onClick={() => onClose()} color="primary">
-              Cancel
+              {cancelLabel}
             </Button>
             <Button onClick={() => onYes()} color="primary" autoFocus>
-              Yes
+              {confirmLabel}
             </Button>
           </div>
         )}

--- a/frontend/src/helper/api/shift.ts
+++ b/frontend/src/helper/api/shift.ts
@@ -1,31 +1,54 @@
 import { getAxiosInstance } from ".";
 
-export const getShifts = async () => {
-  const api = getAxiosInstance()
-  const { data } = await api.get("/shifts?order[date]=DESC&order[startTime]=ASC");
+interface ShiftQuery {
+  weekStartDate?: string;
+}
+
+export const getShifts = async (params?: ShiftQuery) => {
+  const api = getAxiosInstance();
+  const searchParams = new URLSearchParams();
+
+  if (params?.weekStartDate) {
+    searchParams.append("weekStartDate", params.weekStartDate);
+  }
+
+  const queryString = searchParams.toString();
+  const { data } = await api.get(`/shifts${queryString ? `?${queryString}` : ""}`);
   return data;
 };
 
 export const getShiftById = async (id: string) => {
-  const api = getAxiosInstance()
+  const api = getAxiosInstance();
   const { data } = await api.get(`/shifts/${id}`);
   return data;
 };
 
 export const createShifts = async (payload: any) => {
-  const api = getAxiosInstance()
+  const api = getAxiosInstance();
   const { data } = await api.post("/shifts", payload);
   return data;
 };
 
 export const updateShiftById = async (id: string, payload: any) => {
-  const api = getAxiosInstance()
+  const api = getAxiosInstance();
   const { data } = await api.patch(`/shifts/${id}`, payload);
   return data;
 };
 
 export const deleteShiftById = async (id: string) => {
-  const api = getAxiosInstance()
+  const api = getAxiosInstance();
   const { data } = await api.delete(`/shifts/${id}`);
+  return data;
+};
+
+export const getWeekByStart = async (weekStartDate: string) => {
+  const api = getAxiosInstance();
+  const { data } = await api.get(`/weeks/${weekStartDate}`);
+  return data;
+};
+
+export const publishWeek = async (weekStartDate: string) => {
+  const api = getAxiosInstance();
+  const { data } = await api.post(`/weeks/${weekStartDate}/publish`);
   return data;
 };

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,13 +3,17 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
+import { Provider } from "react-redux";
+import { store } from "./store";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>
 );
 

--- a/frontend/src/pages/ShiftForm.tsx
+++ b/frontend/src/pages/ShiftForm.tsx
@@ -1,27 +1,42 @@
-import React, { FunctionComponent, useState } from "react";
-import Grid from "@mui/material/Grid";
-import Card from "@mui/material/Card";
-import CardContent from "@mui/material/CardContent";
+import React, { FunctionComponent, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Grid,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { useForm } from "react-hook-form";
 import { joiResolver } from "@hookform/resolvers/joi";
+import { useHistory, useLocation, useParams } from "react-router-dom";
+import Joi from "joi";
+import { format, parseISO, setMinutes, setSeconds, startOfWeek, addHours } from "date-fns";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
 import { getErrorMessage } from "../helper/error";
 import {
   createShifts,
   getShiftById,
   updateShiftById,
 } from "../helper/api/shift";
-import { useHistory, useParams } from "react-router-dom";
-import Alert from "@mui/material/Alert";
-import TextField from "@mui/material/TextField";
-import Button from "@mui/material/Button";
-import { useEffect } from "react";
-import Joi from "joi";
+import { useTheme } from "@mui/material/styles";
 
 interface IFormInput {
   name: string;
   date: string;
   startTime: string;
   endTime: string;
+}
+
+interface RouteParams {
+  id: string;
 }
 
 const shiftSchema = Joi.object({
@@ -31,83 +46,199 @@ const shiftSchema = Joi.object({
   endTime: Joi.string().required(),
 });
 
-interface RouteParams {
-  id: string;
-}
+const getDefaultTimes = () => {
+  const now = new Date();
+  const startOfHour = setMinutes(setSeconds(now, 0), 0);
+  const startTime = format(startOfHour, "HH:mm");
+  const endTime = format(addHours(startOfHour, 1), "HH:mm");
+  return { startTime, endTime };
+};
 
 const ShiftForm: FunctionComponent = () => {
   const history = useHistory();
   const { id } = useParams<RouteParams>();
-  const isEdit = id !== undefined;
+  const isEdit = Boolean(id);
+  const location = useLocation();
+  const theme = useTheme();
 
-  const [error, setError] = useState("");
+  const searchParams = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const weekParam = searchParams.get("week");
+
+  const defaultWeekStart = useMemo(() => {
+    if (weekParam) {
+      return weekParam;
+    }
+    return format(startOfWeek(new Date(), { weekStartsOn: 1 }), "yyyy-MM-dd");
+  }, [weekParam]);
+
+  const { startTime: defaultStart, endTime: defaultEnd } = getDefaultTimes();
 
   const {
     register,
     handleSubmit,
     formState: { errors },
     setValue,
+    getValues,
   } = useForm<IFormInput>({
     resolver: joiResolver(shiftSchema),
+    defaultValues: {
+      name: "",
+      date: defaultWeekStart,
+      startTime: defaultStart,
+      endTime: defaultEnd,
+    },
   });
 
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [clashShift, setClashShift] = useState<any | null>(null);
+  const [pendingPayload, setPendingPayload] = useState<IFormInput | null>(null);
+
   useEffect(() => {
-    const getData = async () => {
+    const fetchData = async () => {
+      if (!isEdit) {
+        return;
+      }
+
       try {
-        if (!isEdit) {
-          return;
-        }
-
-        const { result } = await getShiftById(id);
-
-        setValue("name", result.name);
-        setValue("date", result.date);
-        setValue("startTime", result.startTime);
-        setValue("endTime", result.endTime);
-      } catch (error) {
-        const message = getErrorMessage(error);
+        const { results } = await getShiftById(id);
+        setValue("name", results.name);
+        setValue("date", results.date);
+        setValue("startTime", results.startTime);
+        setValue("endTime", results.endTime);
+        setPendingPayload({
+          name: results.name,
+          date: results.date,
+          startTime: results.startTime,
+          endTime: results.endTime,
+        });
+      } catch (err) {
+        const message = getErrorMessage(err);
         setError(message);
       }
     };
 
-    getData();
-  }, [isEdit, id, setValue]);
+    fetchData();
+  }, [id, isEdit, setValue]);
+
+  const goBack = () => {
+    const date = getValues("date");
+    const targetWeek = format(startOfWeek(parseISO(date), { weekStartsOn: 1 }), "yyyy-MM-dd");
+    history.push(`/shift?week=${targetWeek}`);
+  };
+
+  const redirectToWeek = (date: string, weekFromResponse?: string) => {
+    const weekStart = weekFromResponse
+      ? weekFromResponse
+      : format(startOfWeek(parseISO(date), { weekStartsOn: 1 }), "yyyy-MM-dd");
+    history.push(`/shift?week=${weekStart}`);
+  };
+
+  const submitShift = async (formData: IFormInput, ignoreClash = false) => {
+    try {
+      setIsSubmitting(true);
+      setError("");
+      const payload = { ...formData, ignoreClash } as any;
+      let response;
+      if (isEdit) {
+        response = await updateShiftById(id, payload);
+      } else {
+        response = await createShifts(payload);
+      }
+      const shift = response.results;
+      redirectToWeek(formData.date, shift.week?.startDate);
+    } catch (err: any) {
+      if (err.response?.status === 409 && err.response?.data?.data?.clashingShift) {
+        setClashShift(err.response.data.data.clashingShift);
+      } else {
+        const message = getErrorMessage(err);
+        setError(message);
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   const onSubmit = async (data: IFormInput) => {
-    try {
-      setError("");
+    setPendingPayload(data);
+    await submitShift(data);
+  };
 
-      if (isEdit) {
-        await updateShiftById(id, data);
-      } else {
-        await createShifts(data);
-      }
-
-      history.push("/shift");
-    } catch (error) {
-      const message = getErrorMessage(error);
-      setError(message);
+  const handleIgnoreClash = async () => {
+    if (!pendingPayload) {
+      setClashShift(null);
+      return;
     }
+    const payload = pendingPayload;
+    setClashShift(null);
+    await submitShift(payload, true);
   };
 
   return (
     <Grid container spacing={3}>
       <Grid item xs={12}>
-        <Card>
-          <CardContent>
-            {error.length > 0 ? <Alert severity="error">{error}</Alert> : <></>}
-            <form onSubmit={handleSubmit(onSubmit)}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Card>
+            <Box
+              sx={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                px: 3,
+                py: 2,
+                borderBottom: `1px solid ${theme.palette.divider}`,
+                backgroundColor: theme.customColors.navy,
+                color: "white",
+              }}
+            >
+              <Button
+                variant="text"
+                onClick={goBack}
+                startIcon={<ChevronLeftIcon sx={{ color: "white" }} />}
+                sx={{
+                  color: "white",
+                  fontWeight: 600,
+                  textTransform: "none",
+                }}
+              >
+                Back
+              </Button>
+              <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                Shift
+              </Typography>
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={isSubmitting}
+                sx={{
+                  backgroundColor: theme.customColors.turquoise,
+                  color: "white",
+                  fontWeight: 600,
+                  "&:hover": {
+                    backgroundColor: theme.customColors.turquoise,
+                  },
+                }}
+              >
+                {isSubmitting ? "Saving..." : "Save"}
+              </Button>
+            </Box>
+            <CardContent>
+              {error && (
+                <Alert severity="error" sx={{ mb: 3 }}>
+                  {error}
+                </Alert>
+              )}
               <Grid container spacing={3}>
-                <Grid item xs={12}>
+                <Grid item xs={12} md={6}>
                   <TextField
                     fullWidth
-                    label="Name"
+                    label="Shift Name"
                     inputProps={{ ...register("name") }}
                     error={!!errors.name}
                     helperText={errors.name?.message}
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid item xs={12} md={6}>
                   <TextField
                     fullWidth
                     label="Date"
@@ -115,12 +246,10 @@ const ShiftForm: FunctionComponent = () => {
                     inputProps={{ ...register("date") }}
                     error={!!errors.date}
                     helperText={errors.date?.message}
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
+                    InputLabelProps={{ shrink: true }}
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid item xs={12} md={6}>
                   <TextField
                     fullWidth
                     label="Start Time"
@@ -128,12 +257,10 @@ const ShiftForm: FunctionComponent = () => {
                     inputProps={{ ...register("startTime") }}
                     error={!!errors.startTime}
                     helperText={errors.startTime?.message}
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
+                    InputLabelProps={{ shrink: true }}
                   />
                 </Grid>
-                <Grid item xs={12}>
+                <Grid item xs={12} md={6}>
                   <TextField
                     fullWidth
                     label="End Time"
@@ -141,21 +268,42 @@ const ShiftForm: FunctionComponent = () => {
                     inputProps={{ ...register("endTime") }}
                     error={!!errors.endTime}
                     helperText={errors.endTime?.message}
-                    InputLabelProps={{
-                      shrink: true,
-                    }}
+                    InputLabelProps={{ shrink: true }}
                   />
                 </Grid>
-                <Grid item xs={12}>
-                  <Button type="submit" variant="contained" color="primary">
-                    Submit
-                  </Button>
-                </Grid>
               </Grid>
-            </form>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        </form>
       </Grid>
+      <Dialog open={!!clashShift} onClose={() => setClashShift(null)}>
+        <DialogTitle>Shift Clash Warning</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This shift clashes with an existing shift.
+          </DialogContentText>
+          {clashShift && (
+            <Box mt={2}>
+              <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+                {clashShift.name}
+              </Typography>
+              <Typography variant="body2">Date: {format(parseISO(clashShift.date), "yyyy-MM-dd")}</Typography>
+              <Typography variant="body2">
+                Time: {clashShift.startTime} - {clashShift.endTime}
+              </Typography>
+            </Box>
+          )}
+          <DialogContentText sx={{ mt: 2 }}>
+            Do you want to proceed anyway?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setClashShift(null)}>Cancel</Button>
+          <Button onClick={handleIgnoreClash} variant="contained">
+            Ignore
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Grid>
   );
 };

--- a/frontend/src/store/hooks.ts
+++ b/frontend/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
+import type { AppDispatch, RootState } from "./index";
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,0 +1,11 @@
+import { combineReducers, createStore } from "redux";
+import scheduleReducer from "./slices/scheduleSlice";
+
+const rootReducer = combineReducers({
+  schedule: scheduleReducer,
+});
+
+export const store = createStore(rootReducer);
+
+export type RootState = ReturnType<typeof rootReducer>;
+export type AppDispatch = typeof store.dispatch;

--- a/frontend/src/store/slices/scheduleSlice.ts
+++ b/frontend/src/store/slices/scheduleSlice.ts
@@ -1,0 +1,136 @@
+import { addDays, format, parseISO, startOfWeek } from "date-fns";
+
+export interface ShiftItem {
+  id: string;
+  name: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  isPublished: boolean;
+  publishedAt: string | null;
+  week?: {
+    id: string | null;
+    startDate: string;
+    endDate: string;
+    isPublished: boolean;
+    publishedAt: string | null;
+  } | null;
+}
+
+export interface WeekInfo {
+  id: string | null;
+  startDate: string;
+  endDate: string;
+  isPublished: boolean;
+  publishedAt: string | null;
+}
+
+interface ScheduleState {
+  selectedWeekStart: string;
+  selectedWeekEnd: string;
+  shifts: ShiftItem[];
+  weekInfo: WeekInfo | null;
+  loading: boolean;
+  publishing: boolean;
+  error: string | null;
+}
+
+const computeWeekRange = (dateString: string) => {
+  const parsed = parseISO(dateString);
+  const start = startOfWeek(parsed, { weekStartsOn: 1 });
+  return {
+    start: format(start, "yyyy-MM-dd"),
+    end: format(addDays(start, 6), "yyyy-MM-dd"),
+  };
+};
+
+const initialWeek = computeWeekRange(
+  format(startOfWeek(new Date(), { weekStartsOn: 1 }), "yyyy-MM-dd")
+);
+
+const initialState: ScheduleState = {
+  selectedWeekStart: initialWeek.start,
+  selectedWeekEnd: initialWeek.end,
+  shifts: [],
+  weekInfo: null,
+  loading: false,
+  publishing: false,
+  error: null,
+};
+
+const SET_SELECTED_WEEK = "schedule/SET_SELECTED_WEEK";
+const SET_SHIFTS = "schedule/SET_SHIFTS";
+const SET_WEEK_INFO = "schedule/SET_WEEK_INFO";
+const SET_LOADING = "schedule/SET_LOADING";
+const SET_ERROR = "schedule/SET_ERROR";
+const SET_PUBLISHING = "schedule/SET_PUBLISHING";
+const REMOVE_SHIFT = "schedule/REMOVE_SHIFT";
+
+interface Action {
+  type: string;
+  payload?: any;
+}
+
+export default function scheduleReducer(
+  state: ScheduleState = initialState,
+  action: Action
+): ScheduleState {
+  switch (action.type) {
+    case SET_SELECTED_WEEK: {
+      const { start, end } = computeWeekRange(action.payload);
+      return { ...state, selectedWeekStart: start, selectedWeekEnd: end };
+    }
+    case SET_SHIFTS:
+      return { ...state, shifts: action.payload };
+    case SET_WEEK_INFO:
+      return { ...state, weekInfo: action.payload };
+    case SET_LOADING:
+      return { ...state, loading: action.payload };
+    case SET_ERROR:
+      return { ...state, error: action.payload };
+    case SET_PUBLISHING:
+      return { ...state, publishing: action.payload };
+    case REMOVE_SHIFT:
+      return {
+        ...state,
+        shifts: state.shifts.filter((shift) => shift.id !== action.payload),
+      };
+    default:
+      return state;
+  }
+}
+
+export const setSelectedWeek = (weekStart: string) => ({
+  type: SET_SELECTED_WEEK,
+  payload: weekStart,
+});
+
+export const setShifts = (shifts: ShiftItem[]) => ({
+  type: SET_SHIFTS,
+  payload: shifts,
+});
+
+export const setWeekInfo = (week: WeekInfo | null) => ({
+  type: SET_WEEK_INFO,
+  payload: week,
+});
+
+export const setLoading = (loading: boolean) => ({
+  type: SET_LOADING,
+  payload: loading,
+});
+
+export const setError = (message: string | null) => ({
+  type: SET_ERROR,
+  payload: message,
+});
+
+export const setPublishing = (publishing: boolean) => ({
+  type: SET_PUBLISHING,
+  payload: publishing,
+});
+
+export const removeShift = (id: string) => ({
+  type: REMOVE_SHIFT,
+  payload: id,
+});


### PR DESCRIPTION
## Summary
- enforce cross-midnight duration limits and overlap detection when creating/updating shifts, with optional clash overrides
- add persistent week entities, read and publish endpoints, and block changes to published weeks
- refresh the scheduler UI with a header week picker, publish controls, clash modal, and Redux-backed state while updating documentation

## Testing
- `npm test` *(backend — fails: jest type definitions are missing in the existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e212cc4c988326a3d57f7a85a11a30